### PR TITLE
Dry run container builds when PR created

### DIFF
--- a/.github/workflows/build_docker_image_dry_run.yml
+++ b/.github/workflows/build_docker_image_dry_run.yml
@@ -1,0 +1,86 @@
+---
+name: create ccs_build container - dry run
+
+on:
+  workflow_dispatch:
+
+  pull_request_target:
+    branches: ['dependabot/**']
+
+  pull_request:
+    types: [opened, synchronize, edited]
+    
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-ccs-base:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.9.0
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Base Image
+        id: docker_build_base
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: install-ccs
+
+  build-cgt-images:
+    runs-on: ubuntu-latest
+    needs: build-ccs-base
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        cgt-versions:
+          - prefix: 18.1.3
+            version-number: 18.1.3.LTS
+            installer-url: 18.1.3.LTS/ti_cgt_msp430_18.1.3.LTS_linux_installer_x86.bin
+          - prefix: 21.6.0
+            version-number: 21.6.0.LTS
+            installer-url: 21.6.0.LTS/ti_cgt_msp430_21.6.0.LTS_linux-x64_installer.bin
+            
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.9.1
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+            
+      - name: Build and Push Images For Specific CGT Versions
+        id: docker_build_cgt_images
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            MSP430_CGT_VERSION=${{ matrix.cgt-versions.version-number }}
+            MSP430_CGT_INSTALLER_URL=${{ matrix.cgt-versions.installer-url }}

--- a/.github/workflows/build_docker_image_dry_run.yml
+++ b/.github/workflows/build_docker_image_dry_run.yml
@@ -81,6 +81,7 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          target: install-specific-cgt
           build-args: |
             MSP430_CGT_VERSION=${{ matrix.cgt-versions.version-number }}
             MSP430_CGT_INSTALLER_URL=${{ matrix.cgt-versions.installer-url }}


### PR DESCRIPTION
To reduce the likelihood of proposed changes preventing docker containers from building carry out a dry run (docker image built but not uploaded).

This improvement isn't perfect as the 2nd stage of the build (installing specific TI CGT versions) has a dependency on a specific tagged version of the `ccs-base` docker image. As such if the CCS version were to be updated then the 2nd stage would not use the updated base image.