### PR TITLE
chore: enhance commitlint workflow for PR title validation

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  pr-title-lint:
+  commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,4 @@
-name: Commitlint
+name: Commit and PR Title Linting
 
 on:
   merge_group:
@@ -9,12 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  commitlint:
+  commit-and-pr-title-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -36,4 +37,4 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx commitlint --verbose
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,12 +5,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,22 +1,20 @@
----
-name: CommitLint
+name: Pull Request Title Linting
+
 on:
   merge_group:
   pull_request:
-permissions: {}
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
 
 jobs:
-  commitlint:
+  pr-title-lint:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -33,3 +31,9 @@ jobs:
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'merge_group'
         run: npx commitlint --last --verbose
+
+      - name: Validate PR title with commitlint
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,4 @@
-name: Pull Request Title Linting
+name: Commitlint
 
 on:
   merge_group:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,4 @@
-name: Commit and PR Title Linting
+name: CommitLint
 
 on:
   merge_group:
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  commit-and-pr-title-lint:
+  commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Updated the GitHub Actions workflow for commit linting to include validation for pull request titles and adjusted permissions.

# Pull Request

## Description

<!-- Describe the changes in this PR and why they are needed. -->

## PR Title Checklist

> [!IMPORTANT]
> The PR title **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
> It is used as the squash-merge commit message onto `main`.

**Format:** `<type>: <description>`

**Supported types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `revert`

**Examples:**

- `feat: add support for new compiler version`
- `fix: correct build failure detection in build script`
- `docs: update README with usage instructions`
- `ci: add commitlint for pull request titles`
- `refactor: simplify Docker image build process`
- `test: add integration tests for build project script`

## Checklist

- [ ] PR title follows the Conventional Commits format
- [ ] Changes are covered by tests (new or existing)
- [ ] All CI checks pass
- [ ] Documentation updated if required (e.g. `README.md`, `action.yml` descriptions)
- [ ] No secrets or sensitive data committed
